### PR TITLE
Bugfix: take first element from array while query product from db

### DIFF
--- a/product-service/src/handlers/getProductById.js
+++ b/product-service/src/handlers/getProductById.js
@@ -8,7 +8,7 @@ export const getProductById = async (event) => {
 
     return {
       statusCode: 200,
-      body: JSON.stringify(product),
+      body: JSON.stringify(product[0]),
     };
   } catch (error) {
     return {


### PR DESCRIPTION
This PR aims to fix a bug while handler `getProductById` sends a response with one retrieved product from DB in the array.

Bypassed wrapping retrieved product from DB into an array (square brackets), returns a product object instead.